### PR TITLE
Update failures_window.lua

### DIFF
--- a/plugins/sasl/data/modules/Custom Module/failures_window.lua
+++ b/plugins/sasl/data/modules/Custom Module/failures_window.lua
@@ -216,7 +216,7 @@ local failures_data = {
             {name="ENG 1\nSTALL", status=false, dataref=FAILURE_ENG_STALL, nr=1 },
             {name="ENG 2\nSTALL", status=false, dataref=FAILURE_ENG_STALL, nr=2 },
             {name="ENG 1\nHUNG START", status=false, dataref=FAILURE_ENG_HUNG_START, nr=1 },
-            {name="ENG 2\nHUNG START", status=false, dataref=FAILURE_ENG_HUNG_START, nr=1 },
+            {name="ENG 2\nHUNG START", status=false, dataref=FAILURE_ENG_HUNG_START, nr=2 },
             
             {name="APU\nFAILURE", status=false, dataref=FAILURE_ENG_APU_FAIL},
             {name="APU\nFIRE!", status=false, dataref=FAILURE_FIRE_APU},


### PR DESCRIPTION
Fix ENG_HUNG_START failure. ENG 2 button triggered error for ENG 1